### PR TITLE
Add interactive menu for single or multiple IP lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,18 @@ pip install -r requirements.txt
 
 ## Uso
 
-Execute o script `ip_lookup.py` informando o IP desejado:
+Execute o script `ip_lookup.py` informando o IP desejado ou rode sem argumentos para abrir o menu interativo:
 
 ```bash
 python ip_lookup.py 8.8.8.8
+# ou simplesmente
+python ip_lookup.py
 ```
 
 Parâmetros adicionais:
 
 - `--hops N` define o número máximo de saltos para o traceroute (padrão 10).
+- `--file ARQUIVO` permite informar um arquivo com uma lista de IPs, um por linha.
 
 O resultado exibirá os dados de WHOIS/ASN, geolocalização e o caminho do traceroute.
 

--- a/ip_lookup.py
+++ b/ip_lookup.py
@@ -44,23 +44,67 @@ def traceroute(ip, hops=10):
         return e.output
 
 
-def main():
-    parser = argparse.ArgumentParser(description='IP information tool')
-    parser.add_argument('ip', help='IP address to query')
-    parser.add_argument('--hops', type=int, default=10, help='Max hops for traceroute')
-    args = parser.parse_args()
-
+def process_ip(ip, hops):
     print('===== WHOIS / ASN =====')
-    whois_info = whois_lookup(args.ip)
+    whois_info = whois_lookup(ip)
     print(whois_info)
 
     print('\n===== GEOLOCATION =====')
-    geo_info = geolocation_lookup(args.ip)
+    geo_info = geolocation_lookup(ip)
     print(geo_info)
 
     print('\n===== TRACEROUTE =====')
-    trace = traceroute(args.ip, args.hops)
+    trace = traceroute(ip, hops)
     print(trace)
+
+
+def process_file(path, hops):
+    try:
+        with open(path, 'r') as f:
+            ips = [line.strip() for line in f if line.strip()]
+    except Exception as e:
+        print(f'Erro ao ler arquivo: {e}')
+        return
+
+    for ip in ips:
+        print(f"\n===== CONSULTANDO {ip} =====")
+        process_ip(ip, hops)
+
+
+def menu(hops):
+    while True:
+        print('\nMenu:')
+        print('1) Inserir um endereço IP')
+        print('2) Informar arquivo com lista de IPs')
+        print('0) Sair')
+        choice = input('Opção: ').strip()
+        if choice == '1':
+            ip = input('Digite o IP: ').strip()
+            if ip:
+                process_ip(ip, hops)
+        elif choice == '2':
+            path = input('Caminho do arquivo: ').strip()
+            if path:
+                process_file(path, hops)
+        elif choice == '0':
+            break
+        else:
+            print('Opção inválida.')
+
+
+def main():
+    parser = argparse.ArgumentParser(description='IP information tool')
+    parser.add_argument('ip', nargs='?', help='IP address to query')
+    parser.add_argument('--file', help='File with list of IP addresses')
+    parser.add_argument('--hops', type=int, default=10, help='Max hops for traceroute')
+    args = parser.parse_args()
+
+    if args.ip:
+        process_ip(args.ip, args.hops)
+    elif args.file:
+        process_file(args.file, args.hops)
+    else:
+        menu(args.hops)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add an interactive menu to lookup one or many IPs
- support `--file` argument to provide a list of IPs
- document new usage in README

## Testing
- `python -m py_compile ip_lookup.py`
- `python ip_lookup.py 1.1.1.1 --hops 1`
- `python ip_lookup.py --file iplist.txt --hops 1`


------
https://chatgpt.com/codex/tasks/task_e_685315879ad0832a95d85bb0bce9c63d