### PR TITLE
Improve IP lookup tool with docs and validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+.env

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Thalles Canela
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Ferramenta em Python para consultar informações de um endereço IP. O programa
 - Python 3.10 ou superior
 - Pacotes listados em `requirements.txt`
 
-Para instalar as dependências:
+Para instalar as dependências (versões indicadas em `requirements.txt`):
 
 ```bash
 pip install -r requirements.txt
@@ -27,6 +27,7 @@ Parâmetros adicionais:
 
 - `--hops N` define o número máximo de saltos para o traceroute (padrão 10).
 - `--file ARQUIVO` permite informar um arquivo com uma lista de IPs, um por linha.
+- `--token TOKEN` ou variável `IPINFO_TOKEN` para autenticar requisições ao IPinfo.
 
 O resultado exibirá os dados de WHOIS/ASN, geolocalização e o caminho do traceroute.
 
@@ -46,4 +47,4 @@ traceroute to 8.8.8.8 (8.8.8.8), 10 hops max
 
 ## Licença
 
-Este projeto está disponível sob a licença MIT.
+Este projeto está disponível sob a licença MIT. Consulte o arquivo `LICENSE` para mais detalhes.

--- a/ip_lookup.py
+++ b/ip_lookup.py
@@ -2,11 +2,23 @@ import argparse
 import subprocess
 import sys
 import shutil
+import os
+import ipaddress
 from ipwhois import IPWhois
 import requests
 
 
+def is_valid_ip(ip: str) -> bool:
+    """Return True if *ip* is a valid IPv4 or IPv6 address."""
+    try:
+        ipaddress.ip_address(ip)
+        return True
+    except ValueError:
+        return False
+
+
 def whois_lookup(ip):
+    """Return RDAP/WHOIS information for *ip* using ipwhois."""
     obj = IPWhois(ip)
     try:
         res = obj.lookup_rdap(depth=1)
@@ -15,9 +27,15 @@ def whois_lookup(ip):
     return res
 
 
-def geolocation_lookup(ip):
+def geolocation_lookup(ip, token=None):
+    """Return geolocation data from ipinfo.io for *ip*."""
+    params = {}
+    if token:
+        params['token'] = token
     try:
-        response = requests.get(f"https://ipinfo.io/{ip}/json", timeout=10)
+        response = requests.get(
+            f"https://ipinfo.io/{ip}/json", params=params, timeout=10
+        )
         if response.status_code == 200:
             return response.json()
         else:
@@ -27,7 +45,7 @@ def geolocation_lookup(ip):
 
 
 def traceroute(ip, hops=10):
-    """Run traceroute/tracert if disponível."""
+    """Run traceroute/tracert for *ip* and return its output."""
     cmd = 'traceroute'
     args = ['-m', str(hops), ip]
     if sys.platform.startswith('win'):
@@ -44,13 +62,18 @@ def traceroute(ip, hops=10):
         return e.output
 
 
-def process_ip(ip, hops):
+def process_ip(ip, hops, token=None):
+    """Lookup and display information for a single IP address."""
+    if not is_valid_ip(ip):
+        print(f"{ip} é inválido.")
+        return
+
     print('===== WHOIS / ASN =====')
     whois_info = whois_lookup(ip)
     print(whois_info)
 
     print('\n===== GEOLOCATION =====')
-    geo_info = geolocation_lookup(ip)
+    geo_info = geolocation_lookup(ip, token=token)
     print(geo_info)
 
     print('\n===== TRACEROUTE =====')
@@ -58,7 +81,8 @@ def process_ip(ip, hops):
     print(trace)
 
 
-def process_file(path, hops):
+def process_file(path, hops, token=None):
+    """Read IPs from *path* and process each one."""
     try:
         with open(path, 'r') as f:
             ips = [line.strip() for line in f if line.strip()]
@@ -67,11 +91,15 @@ def process_file(path, hops):
         return
 
     for ip in ips:
+        if not is_valid_ip(ip):
+            print(f"{ip} é inválido. Pulando...")
+            continue
         print(f"\n===== CONSULTANDO {ip} =====")
-        process_ip(ip, hops)
+        process_ip(ip, hops, token=token)
 
 
-def menu(hops):
+def menu(hops, token=None):
+    """Interactive prompt for querying IPs or files."""
     while True:
         print('\nMenu:')
         print('1) Inserir um endereço IP')
@@ -81,11 +109,11 @@ def menu(hops):
         if choice == '1':
             ip = input('Digite o IP: ').strip()
             if ip:
-                process_ip(ip, hops)
+                process_ip(ip, hops, token=token)
         elif choice == '2':
             path = input('Caminho do arquivo: ').strip()
             if path:
-                process_file(path, hops)
+                process_file(path, hops, token=token)
         elif choice == '0':
             break
         else:
@@ -93,18 +121,22 @@ def menu(hops):
 
 
 def main():
+    """Command-line entry point."""
     parser = argparse.ArgumentParser(description='IP information tool')
     parser.add_argument('ip', nargs='?', help='IP address to query')
     parser.add_argument('--file', help='File with list of IP addresses')
     parser.add_argument('--hops', type=int, default=10, help='Max hops for traceroute')
+    parser.add_argument('--token', help='IPinfo API token (or set IPINFO_TOKEN env var)')
     args = parser.parse_args()
 
+    token = args.token or os.getenv('IPINFO_TOKEN')
+
     if args.ip:
-        process_ip(args.ip, args.hops)
+        process_ip(args.ip, args.hops, token=token)
     elif args.file:
-        process_file(args.file, args.hops)
+        process_file(args.file, args.hops, token=token)
     else:
-        menu(args.hops)
+        menu(args.hops, token=token)
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ipwhois
-requests
+ipwhois==1.3.0
+requests==2.32.4


### PR DESCRIPTION
## Summary
- add MIT LICENSE and `.gitignore`
- pin dependency versions
- validate IPs and show message for invalid inputs
- support IPinfo API token via CLI/env
- document functions with docstrings
- update README with token usage and license reference

## Testing
- `python3 -m py_compile ip_lookup.py`
- `python3 ip_lookup.py --help`

------
https://chatgpt.com/codex/tasks/task_e_685316cf9854832aa639db7d22ca6c22