### PR TITLE
Create result hash after processing IP list

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ Parâmetros adicionais:
 - `--file ARQUIVO` permite informar um arquivo com uma lista de IPs, um por linha.
 - `--token TOKEN` ou variável `IPINFO_TOKEN` para autenticar requisições ao IPinfo.
 - `--full` executa todas as consultas disponíveis.
-- O menu agora possui uma opção para ler uma lista de IPs de um arquivo e
-  salvar as informações de geolocalização em `results_<arquivo>.txt`.
+- O menu possui uma opção para ler uma lista de IPs de um arquivo. Após todas as
+  verificações, é criado automaticamente um arquivo `result_hash.txt` na pasta do
+  projeto contendo o hash das saídas.
 
 Copie o arquivo de exemplo e preencha as credenciais necessárias:
 


### PR DESCRIPTION
## Summary
- generate `result_hash.txt` with a SHA-256 of outputs when processing a file of IPs
- document new result hash behaviour in README

## Testing
- `python -m py_compile ip_lookup.py`

------
https://chatgpt.com/codex/tasks/task_e_6882ea1f4238832aa7cc2750eda2cdb4