### PR TITLE
Add output file option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Parâmetros adicionais:
 - `--token TOKEN` ou variável `IPINFO_TOKEN` para autenticar requisições ao IPinfo.
 - `--full` executa todas as consultas disponíveis.
 - `--history` inclui banners históricos nas consultas ao Shodan (requer conta com Membership).
+- `--output ARQUIVO` salva os resultados no arquivo informado em vez de criar `result_<data>.txt`.
 - O menu possui uma opção para ler uma lista de IPs de um arquivo. Após todas as
   verificações, é criado automaticamente um arquivo `result_data_hora.txt` na pasta do
   projeto contendo todas as saídas. Ferramentas sem retorno não terão seu bloco


### PR DESCRIPTION
## Summary
- add --output option to save query results to a custom file
- allow `process_file` to write to a provided path
- document the new command-line argument in README

## Testing
- `python3 -m py_compile ip_lookup.py`
- `pip check`

------
https://chatgpt.com/codex/tasks/task_e_688392559ba0832aaf513b2d2f18f0b4